### PR TITLE
Cast variables to int before comparing them with numbers

### DIFF
--- a/templates/05-exclusions.rules.j2
+++ b/templates/05-exclusions.rules.j2
@@ -3,7 +3,7 @@
 {% for r in auditd_exclusion_rules %}
 {{ r }}
 {% endfor %}
-{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= 16) or (ansible_os_family == "RedHat" and ansible_distribution_major_version >= '7') %}
+{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 16) or (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) %}
 {% for r in auditd_exclusion_rules2 %}
 {{ r }}
 {% endfor %}

--- a/templates/audit.rules.j2
+++ b/templates/audit.rules.j2
@@ -29,7 +29,7 @@
 {% for r in auditd_exclusion_rules %}
 {{ r }}
 {% endfor %}
-{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= 16) or (ansible_os_family == "RedHat" and ansible_distribution_major_version >= '7') %}
+{% if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int >= 16) or (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) %}
 {% for r in auditd_exclusion_rules2 %}
 {{ r }}
 {% endfor %}


### PR DESCRIPTION
It's never a good thing to compare strings with numbers, and that's
broken completely either by new ansible releases, or using python3
as interpreter. Make sure that we compare numbers with numbers by
casting variables to int when appropriate.

Fixes #1.