### PR TITLE
Fix "No such file or directory" in /proc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,3 +84,8 @@ auditd_failure_mode: 1
 ## ATTENTION! 2 implies any config changes require a system reboot (man auditctl)
 auditd_enable_flag: 2
 #auditd_enable_flag: 1
+# Paths to ignore for suid/sgid files
+auditd_sugid_ignored_paths:
+  - /proc
+  # lxc, docker
+  - /var/lib

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -8,7 +8,7 @@
       until: pkg_result is success
 
     - name: retrieve suid/sgid files list
-      command: find / -path /proc -prune -o -perm  /u=s,g=s -type f
+      command: "find / -path {{ ' -prune -o -path '.join(auditd_sugid_ignored_paths) }} -prune -o -perm /u=s,g=s -type f -print"
       register: sugid_files
       ignore_errors: true
       changed_when: false

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -8,7 +8,7 @@
       until: pkg_result is success
 
     - name: retrieve suid/sgid files list
-      command: find / -perm /u=s,g=s -type f
+      command: find / -path /proc -prune -o -perm  /u=s,g=s -type f
       register: sugid_files
       ignore_errors: true
       changed_when: false


### PR DESCRIPTION
Files in `/proc` are special, and results of errors like ```find: `/proc/32245': No such file or directory```.
This returns a huge Ansible red fatal error.
To overcome this, we can ignore all file in `/proc`.

Side note:
The last release version is `0.9.0`, and before it was `v0.8`. Can the next one be more in line with other roles convention, something like `v0.9.1` or `v0.10.0`?