### PR TITLE
Add rules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,7 @@ auditd_rules_templates:
   - 05-exclusions
   - 10-audit-self
   - 40-base
+  - 43-module-load
   - 50-cis_l2
   - 60-neo23x0
   - 70-rootcmd

--- a/templates/01-start.rules.j2
+++ b/templates/01-start.rules.j2
@@ -1,8 +1,12 @@
 {{ ansible_managed | comment }}
 ## /etc/audit/rules.d/audit.rules
+## https://github.com/linux-audit/audit-userspace/tree/master/rules
 ## https://cisofy.com/controls/ACCT-9630/
 ## http://www.digrouz.com/mediawiki/index.php?title=(RHEL)_HOWTO_configure_the_auditing_of_the_system_(auditd)
 ## https://gist.github.com/Neo23x0/9fe88c0c5979e017a389b90fd19ddfee
+
+## Make the loginuid immutable. This prevents tampering with the auid.
+--loginuid-immutable
 
 ###################
 # Remove any existing rules

--- a/templates/43-module-load.rules.j2
+++ b/templates/43-module-load.rules.j2
@@ -1,0 +1,6 @@
+## These rules watch for kernel module insertion. By monitoring
+## the syscall, we do not need any watches on programs.
+-a always,exit -F arch=b32 -S init_module,finit_module -F key=module-load
+-a always,exit -F arch=b64 -S init_module,finit_module -F key=module-load
+-a always,exit -F arch=b32 -S delete_module -F key=module-unload
+-a always,exit -F arch=b64 -S delete_module -F key=module-unload

--- a/templates/50-cis_l2.rules.j2
+++ b/templates/50-cis_l2.rules.j2
@@ -100,5 +100,4 @@
 -w /sbin/insmod -p x -k modules
 -w /sbin/rmmod -px -k modules
 -w /sbin/modprobe -p x -k modules
--a always,exit -F arch=b64 -S init_module -S delete_module -k modules
 


### PR DESCRIPTION
After reading default auditd rules at https://github.com/linux-audit/audit-userspace/tree/master/rules, I noticed we can add the [one which prevent tempering with auid](https://github.com/linux-audit/audit-userspace/blob/master/rules/11-loginuid.rules) and [other ones for kernel module load/unload  ](https://github.com/linux-audit/audit-userspace/blob/master/rules/43-module-load.rules).