### PR TITLE
Dont restart auditd when augenrules exists

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: augenrules
-  command: augenrules
+  command: augenrules --load
   when: augenrules_file.stat.exists
 
 - name: restart auditd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: augenrules - debian
+- name: augenrules
   command: augenrules
   when: augenrules_file.stat.exists
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,8 @@
     not (ansible_virtualization_type is defined and
           (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker")
         ) and
-    not (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7)
+    not (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) and
+    not augenrules_file.stat.exists
 
 ## https://groups.google.com/forum/#!topic/ansible-project/pv1h1Ne7nSk
 - name: restart auditd - rhel7
@@ -25,7 +26,8 @@
     not (ansible_virtualization_type is defined and
           (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker")
         ) and
-    (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7)
+    (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) and
+    not augenrules_file.stat.exists
 
 - name: restart rsyslog
   service: name=rsyslog state=restarted

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -38,7 +38,7 @@
         backup: yes
       with_items: "{{ auditd_rules_templates }}"
       notify:
-        - augenrules - debian
+        - augenrules
         - restart auditd
         - restart auditd - rhel7
 


### PR DESCRIPTION
Why restart auditd when augenrules has loaded the rules?
