### PR TITLE
Some improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It was tested on the following versions:
 
 ### Operating systems
 
-Ubuntu 14.04, 16.04, 18.04 and Centos7
+* Ubuntu 14.04, 16.04, 18.04
+* Centos7
+* Suse 12.x
 
 ## Example Playbook
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It was tested on the following versions:
 
 * Ubuntu 14.04, 16.04, 18.04
 * Centos7
-* Suse 12.x
+* Suse 12.x, 15.x
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ audisp_syslog_enable: true
 audisp_syslog_target: /var/log/audispd/audispd.log
 #audisp_syslog_target: @@remotesyslog
 
+
 auditd_log_tmp: true
 auditd_log_etc: true
 ## Attention! those three would generate lot of logs. alternatives: sysdig/falco, systemtap, osquery...
@@ -24,6 +25,10 @@ auditd_log_binaries_exec:
   - /usr/bin/ruby2.1
   - /usr/bin/ruby2.2
   - /usr/bin/ruby2.3
+
+# This variable controls wether files not managed by this role will be purged
+# from the rules configuration directory
+auditd_manage_configuration_directory: true
 
 auditd_rules_templates:
   - 01-start

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,3 +104,5 @@ auditd_sugid_ignored_paths:
 auditd_conf_lineinfile:
   # avoid 'dispatch err (pipe full) event lost'
   - { re: '^disp_qos = .*', l: 'disp_qos = lossless' }
+
+auditd_set_loginuid_immutable: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ auditd_rules_templates:
   - 70-rootcmd
   - 71-nobodycmd
   - 90-extra
+  - 91-extra-custom
   - 99-end
 auditd_rule_rootcmd_all: true
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,17 @@
   command: augenrules
   when: augenrules_file.stat.exists
 
+
+- name: restart auditd - suse
+  systemd:
+      name: auditd
+      state: restarted
+  when: >
+    not (ansible_virtualization_type is defined and
+          (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker")
+        ) and ansible_os_family == "Suse"
+
+
 - name: restart auditd
   service:
     name: auditd
@@ -12,7 +23,10 @@
     not (ansible_virtualization_type is defined and
           (ansible_virtualization_type == "lxc" or ansible_virtualization_type == "docker")
         ) and
-    not (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7)
+    not (
+        (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or
+        (ansible_os_family == "Suse" )
+    )
 
 ## https://groups.google.com/forum/#!topic/ansible-project/pv1h1Ne7nSk
 - name: restart auditd - rhel7

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: augenrules - debian
+- name: augenrules
   command: augenrules
   when: augenrules_file.stat.exists
 

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -41,6 +41,7 @@
         - augenrules
         - restart auditd
         - restart auditd - rhel7
+        - restart auditd - suse
 
     # /sbin/augenrules isn't present to generate /etc/audit/audit.rules
     - name: assemble rules into a single file
@@ -58,6 +59,7 @@
       notify:
         - restart auditd
         - restart auditd - rhel7
+        - restart auditd - suse
 
     - name: Check if grub is present
       stat:

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -38,7 +38,7 @@
         backup: "{{ auditd_backup | default(false) }}"
       with_items: "{{ auditd_rules_templates }}"
       notify:
-        - augenrules - debian
+        - augenrules
         - restart auditd
         - restart auditd - rhel7
 

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -24,6 +24,21 @@
         path: "{{ auditd_confdir }}"
         state: directory
 
+    - name: list files in configuration dir
+      shell: "ls {{ auditd_confdir }}"
+      failed_when: no
+      changed_when: no
+      register: confdir_files
+      tags: files
+
+    - name: Delete not managed files in configuration directory
+      file:
+        name: "{{auditd_confdir}}/{{ item }}"
+        state: absent
+      loop: "{{ confdir_files.stdout_lines }}"
+      when: item.replace('.rules','') not in auditd_rules_templates
+      tags: files
+
     - name: check is augenrules is present
       stat:
         path: "/sbin/augenrules"

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -25,7 +25,7 @@
         state: directory
 
     - name: list files in configuration dir
-      shell: "ls {{ auditd_confdir }}"
+      command: "ls {{ auditd_confdir }}"
       failed_when: no
       changed_when: no
       register: confdir_files
@@ -33,7 +33,7 @@
 
     - name: Delete not managed files in configuration directory
       file:
-        name: "{{auditd_confdir}}/{{ item }}"
+        name: "{{ auditd_confdir }}/{{ item }}"
         state: absent
       loop: "{{ confdir_files.stdout_lines }}"
       when: item.replace('.rules','') not in auditd_rules_templates

--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -24,20 +24,23 @@
         path: "{{ auditd_confdir }}"
         state: directory
 
-    - name: list files in configuration dir
-      command: "ls {{ auditd_confdir }}"
-      failed_when: no
-      changed_when: no
-      register: confdir_files
-      tags: files
+    - block:
+      - name: list files in configuration dir
+        command: "ls {{ auditd_confdir }}"
+        failed_when: no
+        changed_when: no
+        check_mode: no
+        register: confdir_files
+        tags: files
 
-    - name: Delete not managed files in configuration directory
-      file:
-        name: "{{ auditd_confdir }}/{{ item }}"
-        state: absent
-      loop: "{{ confdir_files.stdout_lines }}"
-      when: item.replace('.rules','') not in auditd_rules_templates
-      tags: files
+      - name: Delete not managed files in configuration directory
+        file:
+          name: "{{ auditd_confdir }}/{{ item }}"
+          state: absent
+        loop: "{{ confdir_files.stdout_lines }}"
+        when: item.replace('.rules','') not in auditd_rules_templates
+        tags: files
+      when: auditd_manage_configuration_directory
 
     - name: check is augenrules is present
       stat:

--- a/templates/01-start.rules.j2
+++ b/templates/01-start.rules.j2
@@ -6,7 +6,9 @@
 ## https://gist.github.com/Neo23x0/9fe88c0c5979e017a389b90fd19ddfee
 
 ## Make the loginuid immutable. This prevents tampering with the auid.
+{% if auditd_set_loginuid_immutable %}
 --loginuid-immutable
+{% endif %}
 
 ###################
 # Remove any existing rules

--- a/templates/90-extra.rules.j2
+++ b/templates/90-extra.rules.j2
@@ -81,8 +81,3 @@
 -a exit,always -F arch=b64 -S tgkill -k sigkill
 -a exit,always -F arch=b32 -S tgkill -k sigkill
 
-# Extra rules
-{% for r in auditd_extra_rules %}
-{{ r }}
-{% endfor %}
-

--- a/templates/91-extra-custom.rules.j2
+++ b/templates/91-extra-custom.rules.j2
@@ -1,0 +1,5 @@
+
+# Extra rules
+{% for r in auditd_extra_rules %}
+{{ r }}
+{% endfor %}

--- a/vars/Suse.yml
+++ b/vars/Suse.yml
@@ -1,0 +1,3 @@
+auditd_pkg: audit
+
+syslog_user: root


### PR DESCRIPTION
Hi, 

I've used your role to deploy auditd to a bunch of systems in it worked quite good. I've added some features to fully acomplish the task that could be useful for others: 

* Added support for Suse: Just added a handler for Suse that uses the systemd module. I've only tested with Suse12 but it might work for Suse 15 also. 
* Added two tasks to delete not managed files within rules configuration directory. I think that all configuration there must be managed by the role. 
* Added a variable to disable --loginuuid-immutable option. Not too old auditd versions do not support it
* Move auditd_extra_rules to a new template. This allows to configure systems with fully customized rules if needed. 
* Renamed agenrules - debian handler to 'agenrules' as it's not used only on debian


