### PR TITLE
Add audit_plugins directory variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ osquery_process_auditing: false
 audisp_syslog_enable: true
 audisp_syslog_target: /var/log/audispd/audispd.log
 # audisp_syslog_target: @@remotesyslog
+auditd_plugins_folder: /etc/audisp/plugins.d
+# Change for auditd 3
+# auditd_plugins_folder: /etc/audit/plugins.d
 
 auditd_grub_enable: false
 

--- a/tasks/laurel.yml
+++ b/tasks/laurel.yml
@@ -44,7 +44,7 @@
 - name: Set laurel audit plugin configuration
   ansible.builtin.template:
     src: "{{ auditd_laurel_plugin }}"
-    dest: /etc/audisp/plugins.d/laurel.conf
+    dest: "{{ auditd_plugins_folder }}/laurel.conf"
     mode: '0644'
   notify:
     - Restart auditd

--- a/tasks/rsyslog-audisp.yml
+++ b/tasks/rsyslog-audisp.yml
@@ -43,7 +43,7 @@
 
 - name: Ensure audis syslog plugin is enabled
   community.general.ini_file:
-    path: /etc/audisp/plugins.d/syslog.conf
+    path: "{{ auditd_plugins_folder }}/syslog.conf"
     section: null
     option: active
     value: 'yes'


### PR DESCRIPTION
Auditd version 3 uses a different directory for plugins this change allows settings the plugins directory with a variable.

<!--- Provide a general summary of your changes in the Title above -->

## Description
A variable `auditd_plugins_folder` was introduced. The default value reflects the original code.
This variable allows changing the auditd plugins folder. Starting with auditd version 3 the plugins folder is at `/etc/audit/plugins.d`. [Laurel Documentation](https://github.com/threathunters-io/laurel/blob/18c2b900fef02f24f8b85709db5be0cb78b6716e/INSTALL.md#set-up-auditd-to-use-laurel-and-configure-laurel-itself)

This change allows overriding the directory using vars. However it does not automatically choose the correct path based on the version installed.

## Motivation and Context
Without this change the module does not work with auditd version 3.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually by running it with the variable set and unset and automatically by running the lint github action.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
